### PR TITLE
T31 upgrade pyspark Fixes #31

### DIFF
--- a/Dockerfile-spark
+++ b/Dockerfile-spark
@@ -51,13 +51,13 @@ RUN curl -sL --retry 3 \
  && chown -R root:root $HADOOP_HOME
 
 # SPARK
-ENV SPARK_VERSION 2.3.0
+ENV SPARK_VERSION 2.3.2
 ENV SPARK_PACKAGE spark-${SPARK_VERSION}-bin-without-hadoop
 ENV SPARK_HOME /usr/spark-${SPARK_VERSION}
 ENV SPARK_DIST_CLASSPATH="$HADOOP_HOME/etc/hadoop/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/yarn/lib/*:$HADOOP_HOME/share/hadoop/yarn/*:$HADOOP_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_HOME/share/hadoop/mapreduce/*:$HADOOP_HOME/share/hadoop/tools/lib/*"
 ENV PATH $PATH:${SPARK_HOME}/bin
 RUN curl -sL --retry 3 \
-  "https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-without-hadoop.tgz" \
+  "https://archive.apache.org/dist/spark/spark-2.3.2/spark-2.3.2-bin-without-hadoop.tgz" \
   | gunzip \
   | tar x -C /usr/ \
  && mv /usr/$SPARK_PACKAGE $SPARK_HOME \

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   loader:
-      #image: gwul/tweetsets-loader
-      build:
-          context: ..
-          dockerfile: Dockerfile-loader
+      image: gwul/tweetsets-loader
+      #build:
+      #    context: ..
+      #    dockerfile: Dockerfile-loader
       logging:
           driver: json-file
           options:

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   loader:
-      image: gwul/tweetsets-loader
-      # build:
-      #    context: ..
-      #    dockerfile: Dockerfile-loader
+      #image: gwul/tweetsets-loader
+      build:
+          context: ..
+          dockerfile: Dockerfile-loader
       logging:
           driver: json-file
           options:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ urllib3==1.25.2
 vine==1.1.3
 Werkzeug==1.0.1
 twarc==1.4.0
-pyspark==2.3.0
+pyspark==2.3.2


### PR DESCRIPTION
Instructions:

On the primary node's VM, do the following:
```
docker rmi ts_worker ts_spark-master
docker-compose build --no-cache
```
On the secondary VM, do the following:
```
docker rmi ts_spark-worker
docker-compose build --no-cache
```
Then do `docker-compose up -d` on both. 

Please test loading with the spark-loader:
```
docker-compose -f loader.docker-compose.yml run --rm loader /bin/bash

spark-submit \
 --jars elasticsearch-hadoop.jar \
 --master spark://$SPARK_MASTER_HOST:7101 \
 --py-files dist/TweetSets-2.0-py3.6.egg,dependencies.zip \
 --conf spark.driver.bindAddress=0.0.0.0 \
 --conf spark.driver.host=$SPARK_DRIVER_HOST \
 tweetset_loader.py spark-create /dataset/path/to/files
```

**Note**: I had to comment out the `image` line and uncomment the `build` instructions in `loader.docker-compose.yml`. Those changes are part of this commit, but we'll want to revert back once the image is updated in Docker.
