### PR TITLE
Fixes #65 Removed urrlib from requirements.txt

### DIFF
--- a/Dockerfile-spark
+++ b/Dockerfile-spark
@@ -51,13 +51,13 @@ RUN curl -sL --retry 3 \
  && chown -R root:root $HADOOP_HOME
 
 # SPARK
-ENV SPARK_VERSION 2.3.0
+ENV SPARK_VERSION 2.3.2
 ENV SPARK_PACKAGE spark-${SPARK_VERSION}-bin-without-hadoop
 ENV SPARK_HOME /usr/spark-${SPARK_VERSION}
 ENV SPARK_DIST_CLASSPATH="$HADOOP_HOME/etc/hadoop/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/yarn/lib/*:$HADOOP_HOME/share/hadoop/yarn/*:$HADOOP_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_HOME/share/hadoop/mapreduce/*:$HADOOP_HOME/share/hadoop/tools/lib/*"
 ENV PATH $PATH:${SPARK_HOME}/bin
 RUN curl -sL --retry 3 \
-  "https://archive.apache.org/dist/spark/spark-2.3.0/spark-2.3.0-bin-without-hadoop.tgz" \
+  "https://archive.apache.org/dist/spark/spark-2.3.2/spark-2.3.2-bin-without-hadoop.tgz" \
   | gunzip \
   | tar x -C /usr/ \
  && mv /usr/$SPARK_PACKAGE $SPARK_HOME \

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   loader:
       image: gwul/tweetsets-loader
-      # build:
+      #build:
       #    context: ..
       #    dockerfile: Dockerfile-loader
       logging:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ urllib3==1.25.2
 vine==1.1.3
 Werkzeug==1.0.1
 twarc==1.4.0
-pyspark==2.3.0
+pyspark==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyparsing==2.2.0
 python-dateutil==2.6.0
 pytz==2017.2
 redis==2.10.6
-requests==2.22.0
+requests==2.23.0
 six==1.10.0
 vine==1.1.3
 Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyparsing==2.2.0
 python-dateutil==2.6.0
 pytz==2017.2
 redis==2.10.6
-requests==2.23.0
+requests==2.25.0
 six==1.10.0
 vine==1.1.3
 Werkzeug==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ pytz==2017.2
 redis==2.10.6
 requests==2.22.0
 six==1.10.0
-urllib3==1.25.2
 vine==1.1.3
 Werkzeug==1.0.1
 twarc==1.4.0


### PR DESCRIPTION
Created a new branch for this fix because the dependabot was out of sync with master and couldn't be rebased easily, it seemed.

Without pinning the dependancy, urllib 1.26.2 is installed by default.

