### PR TITLE
T94 email on export -- fixes #94

### DIFF
--- a/docker/example.cluster-primary.docker-compose.yml
+++ b/docker/example.cluster-primary.docker-compose.yml
@@ -134,6 +134,13 @@ services:
         - LOGGING_LEVEL=${WORKER_LOGGING_LEVEL}
         - TZ
         - ES_TIMEOUT
+        - EMAIL_PORT
+        - EMAIL_SMTP
+        - EMAIL_FROM
+        - EMAIL_USERNAME
+        - EMAIL_PASSWORD
+        - ADMIN_EMAIL
+        - USE_TLS
       restart: always
   spark-master:
       image: gwul/tweetsets-spark

--- a/docker/example.docker-compose.yml
+++ b/docker/example.docker-compose.yml
@@ -172,6 +172,13 @@ services:
         - LOGGING_LEVEL=${WORKER_LOGGING_LEVEL}
         - TZ
         - ES_TIMEOUT
+        - EMAIL_PORT
+        - EMAIL_SMTP
+        - EMAIL_FROM
+        - EMAIL_USERNAME
+        - EMAIL_PASSWORD
+        - ADMIN_EMAIL
+        - USE_TLS
       restart: always
   # This will exit. That's OK.
   loader:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ click==7.1.2
 elasticsearch~=7.10
 elasticsearch-dsl~=7.3
 Flask==1.1.2
+Flask-Mail==0.9.1
 idna==2.5
 itsdangerous==1.1.0
 Jinja2==2.11.2

--- a/tasks.py
+++ b/tasks.py
@@ -79,28 +79,26 @@ def generate_tasks(self, task_defs, dataset_params, total_tweets, dataset_path, 
     generate_task_filepath = os.path.join(dataset_path, 'generate_tasks.json')
     if os.path.exists(generate_task_filepath):
         os.remove(generate_task_filepath)
-
-    #msg = task_defs['message_obj']
-    #msg.subject = 'TweetSets Data Extract Complete'
-    #msg.body = 'Your data extract is ready.'
-    #task_defs['mailer'].send(msg)
-    #logger.debug(self.app.conf)
+    # Notify user if email provided
     if task_defs.get('requester_email'):
-        send_email(task_defs['requester_email'])
-        
+        send_email(email_address=task_defs['requester_email'],
+                    dataset_name=dataset_params['dataset_name'],
+                    url_for_extract=task_defs['dataset_url'])
+
     return {'current': tweet_count + 1, 'total': total_tweets,
             'status': 'Completed.'}
 
-def send_email(email_address):
-    # Send email on task completion
+def send_email(email_address, dataset_name, url_for_extract):
+    '''Sends an email on task completion to the user requesting the extract.'''
+    # Get current Flask app context (for configuration variables)
     app = current_app._get_current_object()
     mail = Mail(app)
     msg = Message(subject='TweetSets Data Extract Complete',
                 sender=app.config['ADMIN_EMAIL'],
                 recipients=[email_address])
-    # To Do --> Add path to dataset
-    msg.body = 'Your data extract is ready.'
+    msg.html = 'Your data extract for dataset <em>{}</em> is ready <a href={}>for downloading</a>.'.format(dataset_name, url_for_extract)
     mail.send(msg)
+    return
 
 class BaseGenerateTask:
     def __init__(self, state, total_tweets, dataset_path, generate_update_increment, file_filter=None, source=None):

--- a/tasks.py
+++ b/tasks.py
@@ -94,7 +94,7 @@ def send_email(email_address, dataset_name, url_for_extract):
     app = current_app._get_current_object()
     mail = Mail(app)
     msg = Message(subject='TweetSets Data Extract Complete',
-                sender=app.config['ADMIN_EMAIL'],
+                sender=app.config['EMAIL_FROM'],
                 recipients=[email_address])
     msg.html = 'Your data extract for dataset <em>{}</em> is ready <a href={}>for downloading</a>.'.format(dataset_name, url_for_extract)
     mail.send(msg)

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -550,6 +550,12 @@
                             <div class="panel-body">
                                 {% if total_tweets > 0 %}
                                 <form id="datasetExportsForm" class="form-horizontal" action="{{ url_for('dataset', dataset_id=dataset_id) }}" method="POST">
+                                    <div class="">
+                                        <label>
+                                            <input type="text" name="requester_email" value="">
+                                            <p class="help-block">Please enter an email address so that we may notify you if there are problems with your export.</p>
+                                        </label>
+                                    </div>
                                     {% if is_local_mode %}
                                        <div class="checkbox">
                                           <label>

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -550,10 +550,10 @@
                             <div class="panel-body">
                                 {% if total_tweets > 0 %}
                                 <form id="datasetExportsForm" class="form-horizontal" action="{{ url_for('dataset', dataset_id=dataset_id) }}" method="POST">
-                                    <div class="">
-                                        <label>
-                                            <input type="text" name="requester_email" value="">
+                                    <div class="form-horizontal">
+                                        <label for="emailInput">
                                             <p class="help-block">Please enter an email address so that we may notify you if there are problems with your export.</p>
+                                            <input type="text" class="form-control" id="emailInput" name="requester_email" value="" placeholder="Email">
                                         </label>
                                     </div>
                                     {% if is_local_mode %}

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -11,6 +11,13 @@
       $( "#created_at_to" ).datepicker(options);
     } );
 
+    function isEmail(email) {
+        /* From https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address */
+        var regex = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+        return regex.test(email);
+    }
+
+
     function toCSV(data, filename) {
         /* Create CSV from JSON. From https://stackoverflow.com/questions/16078544/export-to-csv-using-jquery-and-html */
         let csv = Papa.unparse(data);
@@ -552,7 +559,7 @@
                                 <form id="datasetExportsForm" class="form-horizontal" action="{{ url_for('dataset', dataset_id=dataset_id) }}" method="POST">
                                     <div class="form-horizontal">
                                         <label for="emailInput">
-                                            <p class="help-block">Please enter an email address so that we may notify you if there are problems with your export.</p>
+                                            <p class="help-block">Please enter an email address so that we may notify you when your export is ready.</p>
                                             <input type="text" class="form-control" id="emailInput" name="requester_email" value="" placeholder="Email">
                                         </label>
                                     </div>
@@ -579,7 +586,7 @@
                                           <p class="help-block">Generate files containing the tweet ids of the dataset.</p>
                                       </label>
                                     </div>
-                                    <button type="submit" form="datasetExportsForm" name="generate_tasks" value="true" class="btn btn-primary" {% if task_id %} disabled="true" {% endif %}>Generate</button>
+                                    <button type="submit" id="datasetExportsId" form="datasetExportsForm" name="generate_tasks" value="true" class="btn btn-primary" {% if task_id %} disabled="true" {% endif %}>Generate</button>
                                 </form>
                                 {% else %}
                                 <div class="alert alert-warning" role="alert" atomic-live="true">No tweets found with the current dataset parameters. Please refine the dataset parameters to create an export.</div>
@@ -644,12 +651,29 @@
         $(".csv_download_link").on("click", function(e) {
             /* Get the ID of the target clicked.*/
             let link_id = $(e.target).attr("id");
-            /* Prevent click propagation. */
-            e.stopPropagation();
             /* Get data associated with this id. */
             let data = $("#stats-panel").data(link_id);
             /* Call toCSV() on this element. */
             toCSV.apply(this, [data, link_id + ".csv"]);
         });
+        $("#datasetExportsForm").on("submit", function(e) {
+            /* Remove the alert if it exists */
+            $("#emailAlert").remove
+            /* Get the value of the email input element */
+            let form = $(e.currentTarget),
+                email = form.find("#emailInput").val();
+            /* Validate */
+            if (isEmail(email)) {
+                return;
+            }
+            else {
+                e.preventDefault();
+                /* Add an alert element if not already present. */
+                let emailAlert = $("#emailAlert");
+                if (emailAlert.length == 0) {
+                    form.append("<div class='alert alert-warning' role='alert' id='emailAlert'>Please enter a valid email address</div>");
+                }
+            }
+        })
 </script>
 {% endblock %}

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -560,7 +560,7 @@
                                     <div class="form-horizontal">
                                         <label for="emailInput">
                                             <p class="help-block">Please enter an email address so that we may notify you when your export is ready.</p>
-                                            <input type="text" class="form-control" id="emailInput" name="requester_email" value="" placeholder="Email">
+                                            <input type="text" class="form-control" id="emailInput" name="requester_email" value="" placeholder="Email" required>
                                         </label>
                                     </div>
                                     {% if is_local_mode %}
@@ -671,7 +671,7 @@
                 /* Add an alert element if not already present. */
                 let emailAlert = $("#emailAlert");
                 if (emailAlert.length == 0) {
-                    form.append("<div class='alert alert-warning' role='alert' id='emailAlert'>Please enter a valid email address</div>");
+                    form.after("<div class='alert alert-warning' role='alert' id='emailAlert'>Please enter a valid email address</div>");
                 }
             }
         })

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -189,9 +189,16 @@ def dataset(dataset_id):
     context['filenames_list'] = filenames_list
 
     context['dataset_id'] = dataset_id
+<<<<<<< HEAD
 
     context['consent_html'] = app.config['CONSENT_HTML']
     context['consent_button_text'] = app.config['CONSENT_BUTTON_TEXT']
+=======
+    # Save the user's emails to the dataset params file (if supplied)
+    if request.form.get('requester_email'):
+        dataset_params['requester_email'] = request.form['requester_email']
+        write_json(os.path.join(dataset_path, 'dataset_params.json'), dataset_params)
+>>>>>>> Email field added and saves to dataset_params.json
 
     return render_template('dataset.html', **context)
 
@@ -476,7 +483,7 @@ def _dataset_params_to_context(dataset_params):
     context = dict()
     for key, value in dataset_params.items():
         # Ignore email in dataset_params.json
-        if key == 'requestor_email':
+        if key == 'requester_email':
             continue
         if key != 'dataset_name':
             context['limit_{}'.format(key)] = value
@@ -493,6 +500,7 @@ def _form_to_dataset_params(form):
     dataset_params['source_dataset'] = form['limit_source_datasets']
     if 'dataset_name' in form:
         dataset_params['dataset_name'] = form['dataset_name']
+
     return dataset_params
 
 

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -189,16 +189,12 @@ def dataset(dataset_id):
     context['filenames_list'] = filenames_list
 
     context['dataset_id'] = dataset_id
-<<<<<<< HEAD
-
     context['consent_html'] = app.config['CONSENT_HTML']
     context['consent_button_text'] = app.config['CONSENT_BUTTON_TEXT']
-=======
     # Save the user's emails to the dataset params file (if supplied)
     if request.form.get('requester_email'):
         dataset_params['requester_email'] = request.form['requester_email']
         write_json(os.path.join(dataset_path, 'dataset_params.json'), dataset_params)
->>>>>>> Email field added and saves to dataset_params.json
 
     return render_template('dataset.html', **context)
 

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -475,6 +475,9 @@ def _dataset_path(dataset_id):
 def _dataset_params_to_context(dataset_params):
     context = dict()
     for key, value in dataset_params.items():
+        # Ignore email in dataset_params.json
+        if key == 'requestor_email':
+            continue
         if key != 'dataset_name':
             context['limit_{}'.format(key)] = value
         else:

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -83,7 +83,7 @@ if not app.debug and app.config['ADMIN_EMAIL'] and app.config['EMAIL_SMTP'] and 
     mail_handler = SMTPHandler((app.config['EMAIL_SMTP'], app.config['EMAIL_PORT']),
                                app.config['EMAIL_FROM'],
                                [app.config['ADMIN_EMAIL']], 'TweetSet error on {}'.format(app.config['HOST']),
-                               credentials=('sfm_no_reply@email.gwu.edu', 'noreply4SFM!'), secure=secure)
+                               credentials=('sfm_no_reply@email.gwu.edu', app.config['EMAIL_PASSWORD']), secure=secure)
     mail_handler.setLevel(logging.ERROR)
     app.logger.addHandler(mail_handler)
 

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,24 @@ from datetime import datetime
 import re
 from elasticsearch_dsl import Search, Q
 from models import get_tweets_index_name
+from celery import Celery
+
+def make_celery(app):
+    '''As described in Flask documentation. Adds a Flask application context to the Celery worker thread.'''
+    celery = Celery(
+        app.name,
+        backend=app.config['CELERY_RESULT_BACKEND'],
+        broker=app.config['CELERY_BROKER_URL']
+    )
+    celery.conf.update(app.config)
+
+    class ContextTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery
 
 
 def write_json(filepath, obj):


### PR DESCRIPTION
Email address is a required & validated field for submitting a request for dataset extracts. Email address is saved to the `dataset_params.json` file. The Celery task sends an email on completion of the requested extracts. 

Note that it's necessary to modify the `worker` section of the `docker-compose.yml` file on the primary node. (Duplication of environment variables from the `server` section ensures that the former are available to the Celery worker for use with `flask-mail`.) 

Successfully tested with up to 50 simultaneous jobs. Simultaneous jobs that use the same `dataset_name` seem to trigger SMTP errors, but that situation seems unlikely to occur in practice. (Simultaneous jobs with different `dataset_name`s go through as expected.)

I'm still not sure why `sfm_no_reply@email.gwu.edu` wasn't working yesterday. We may want to monitor that closely in production to make sure users are getting notified.

For testing: 

- Create a new dataset extract.
- Modify an existing extract and submit again.
- Submit a few longer-running dataset extracts in parallel.  