### PR TITLE
Fixes logic for determining if dataset request is for a full dataset

### DIFF
--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -229,7 +229,9 @@
                                 <div class="form-group">
                                     <label for="created_at_from" class="col-sm-2 control-label">From<span class="sr-only">, format as 4 digit year hyphen 2 digit month hyphen 2 digit day</span></label>
                                     <div class="col-sm-2">
-                                        <input type="text" class="form-control" id="created_at_from" name="limit_created_at_from" value="{{ limit_created_at_from }}" pattern="[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}">
+                                        <!-- Date validation pattern from https://www.html5pattern.com/Dates -->
+                                        <input type="text" class="form-control" id="created_at_from" name="limit_created_at_from" value="{{ limit_created_at_from }}" pattern="(20)[0-9]{2}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1[0-9]|2[0-9])|(?:(?!02)(?:0[1-9]|1[0-2])-(?:30))|(?:(?:0[13578]|1[02])-31))" 
+                                        oninvalid="setCustomValidity('Use date format YYYY-MM-DD')" oninput="setCustomValidity('')">
                                     </div>
                                     <div class="col-sm-7">
                                         <p class="help-block">Created at date is greater than or equal to. Includes tweets from 00:00:00 UTC on this date.  {% if created_at_min %} First tweet in limited dataset is {{ created_at_min.strftime('%Y-%m-%d') }}.{% endif %}{% if dataset_created_at_min %} First tweet in source dataset is {{ dataset_created_at_min.strftime('%Y-%m-%d') }}.{% endif %}</p>
@@ -238,7 +240,8 @@
                                 <div class="form-group">
                                     <label for="created_at_to" class="col-sm-2 control-label">To<span class="sr-only">, format as 4 digit year hyphen 2 digit month hyphen 2 digit day</span></label>
                                     <div class="col-sm-2">
-                                        <input type="text" class="form-control" id="created_at_to" name="limit_created_at_to" value="{{ limit_created_at_to }}" pattern="[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}">
+                                        <input type="text" class="form-control" id="created_at_to" name="limit_created_at_to" value="{{ limit_created_at_to }}" pattern="(20)[0-9]{2}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1[0-9]|2[0-9])|(?:(?!02)(?:0[1-9]|1[0-2])-(?:30))|(?:(?:0[13578]|1[02])-31))"
+                                         oninvalid="setCustomValidity('Use date format YYYY-MM-DD')" oninput="setCustomValidity('')">
                                     </div>
                                     <div class="col-sm-7">
                                         <p class="help-block">Created at date is less than or equal to. Includes tweets through 23:59:59 UTC on this date. {% if created_at_max %} Last tweet in limited dataset is {{ created_at_max.strftime('%Y-%m-%d') }}.{% endif %}{% if dataset_created_at_max %} Last tweet in source dataset is {{ dataset_created_at_max.strftime('%Y-%m-%d') }}.{% endif %}</p>

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -299,8 +299,6 @@
                                         {% if not dataset_id %}
                                             <button type="submit" class="btn btn-primary">Preview</button>
                                             <p class="help-block">Get a sample of tweets in the dataset and see dataset statistics.</p>
-                                            <button type="button" class="btn btn-primary datasetNameModal">Create dataset</button>
-                                            <p class="help-block">Freeze the dataset parameters to allow generating dataset exports.</p>
                                             <input type="hidden"  name="dataset_name" value="" />
 
                                         {% else %}

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -327,7 +327,7 @@
 
                     /* check for empty form limits before redirecting or showing modal */
                     $( ".datasetNameModal" ).click(function() {
-                        if( !$('textarea').val() &&
+			 if ($('textarea').filter(function() { return this.value === ''; }).length === 10 &&
                             !$('input[name*="limit_has_"]').is(':checked') &&
                             !$('input[type="text"]').val() &&
                             !$('input[type="number"]').val() &&

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -327,17 +327,17 @@
 
                     /* check for empty form limits before redirecting or showing modal */
                     $( ".datasetNameModal" ).click(function() {
-			            if ($('textarea').filter(function() { return !$(this).val() }).length === 10 &&
-                            !$('input[name*="limit_has_"]').is(':checked') &&
-                            /* two text type inputs, for Created At dates */
-                            $('input[id^=created_at').filter(function() { return !$(this).val() }).length === 2 &&
-                            /* one number type input, for Limit */
-                            $('input[type="number"]').filter(function() { return !$(this).val() }).length === 1 &&
-                            $('input[name^="limit_tweet_type_"]:checked').length === 4 ) {
-                              $('input[name="is_full_dataset"]').val(true);
-                              $('#limitForm').submit(); 
+                        if ($('textarea').filter(function() { return !$(this).val() }).length === 10 && 
+                        !$('input[name*="limit_has_"]').is(':checked') &&
+                        /* two text type inputs, for Created At dates */
+                        $('input[id^=created_at').filter(function() { return !$(this).val() }).length === 2 &&
+                        /* one number type input, for Limit */
+                        $('input[type="number"]').filter(function() { return !$(this).val() }).length === 1 &&
+                        $('input[name^="limit_tweet_type_"]:checked').length === 4 ) {
+                          $('input[name="is_full_dataset"]').val(true);
+                          $('#limitForm').submit(); 
                         } else { 
-                            $('#datasetNameModal').modal('show') 
+                          $('#datasetNameModal').modal('show') 
                         }
                     });
 

--- a/templates/dataset.html
+++ b/templates/dataset.html
@@ -327,13 +327,15 @@
 
                     /* check for empty form limits before redirecting or showing modal */
                     $( ".datasetNameModal" ).click(function() {
-			 if ($('textarea').filter(function() { return this.value === ''; }).length === 10 &&
+			            if ($('textarea').filter(function() { return !$(this).val() }).length === 10 &&
                             !$('input[name*="limit_has_"]').is(':checked') &&
-                            !$('input[type="text"]').val() &&
-                            !$('input[type="number"]').val() &&
+                            /* two text type inputs, for Created At dates */
+                            $('input[id^=created_at').filter(function() { return !$(this).val() }).length === 2 &&
+                            /* one number type input, for Limit */
+                            $('input[type="number"]').filter(function() { return !$(this).val() }).length === 1 &&
                             $('input[name^="limit_tweet_type_"]:checked').length === 4 ) {
-                            $('input[name="is_full_dataset"]').val(true);
-                            $('#limitForm').submit(); 
+                              $('input[name="is_full_dataset"]').val(true);
+                              $('#limitForm').submit(); 
                         } else { 
                             $('#datasetNameModal').modal('show') 
                         }


### PR DESCRIPTION
In addition to fixing the logic for determining if any criteria has been entered by the user, improves date field validation (via pattern regex) and HTML5 error message. 

Changes included:
1) Keeps form validation client-side. 
2) Removes the Create Dataset button from the Dataset Parameters tab. User must go to the Preview (or Sample Tweets) tabs. 
3) Keeps modal for dataset name as is.

I overrode the message for an invalid date to say, "Use date format YYYY-MM-DD". The updated pattern is from https://www.html5pattern.com/Dates. Note that if the user enters a date before 2000 (e.g. 1999-01-01), the HTML5 error is still "Use date format YYYY-MM-DD" which is technically what they did. Twitter didn't exist in the 20th century so it would be an unusual situation to enter a date from the 1900s but open to other non-wordy error message text if deemed needed. 

