### PR TITLE
T140 path to extracts: #140

### DIFF
--- a/docker/example.cluster-node.docker-compose.yml
+++ b/docker/example.cluster-node.docker-compose.yml
@@ -58,6 +58,7 @@ services:
         - tweetsets
       volumes:
         - ${DATASET_PATH}:/dataset
+        - ${TWEETSETS_DATA_PATH}/full_datasets:/tweetsets_data/full_datasets
       restart: always
 networks:
   tweetsets:

--- a/docker/example.env
+++ b/docker/example.env
@@ -62,6 +62,11 @@ SPARK_BLOCKMANAGER_PORT=8980
 # These should be good default settings.
 SPARK_MEMORY=2g
 SPARK_CORES=2
+# Adjust this value to constrain the size of the full extracts created by the Spark loader
+SPARK_MAX_FILE_SIZE=2g
+# This value determines the number of partitions used by Spark for loading and extracting. Generally, it should be a value between 100 and 1000 MB. Tweaking this value may improve performance in some cases.
+SPARK_PARTITION_SIZE=512m
+
 
 # DOCKER LOG CONFIGURATION
 # This limits the size of the logs kept by Docker for each container.

--- a/docker/example.vhost.conf
+++ b/docker/example.vhost.conf
@@ -5,8 +5,18 @@ send_timeout                180;
 proxy_buffer_size           128k;
 proxy_buffers               4 256k;
 proxy_busy_buffers_size     256k;
-#location ~* /full-dataset-file/.*\.(csv\.zip|jsonl\.zip)$
-#        proxy_pass <hostname>;
-#        allow <ip range in CIDR format>;
-#        deny all;
+#location ~* "/full-dataset-file/[0-9a-zA-Z]{6}/(tweet-csv|tweet-json).*" {
+#    proxy_pass <hostname>;
+#    allow <IP range in CIDR format>; 
+#    deny all;
+#}
+#location ~* "/full-dataset-file/[0-9a-zA-Z]{6}/tweets-.*(csv\.zip|jsonl\.zip)$" {
+#    proxy_pass <hostname>;
+#    allow <IP range in CIDR format>;
+#    deny all;
+#}
+#location ~* "/dataset-file/[0-9a-zA-Z]{8}/tweets-.*(csv\.zip|jsonl\.zip)$" {
+#    proxy_pass <hostname>;
+#    allow <IP range in CIDR format>;
+#    deny all;
 #}

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -12,6 +12,7 @@ services:
               max-file: ${DOCKER_LOG_MAX_FILE}
       volumes:
         - ${DATASET_PATH}:/dataset
+        - ${TWEETSETS_DATA_PATH}/full_datasets:/tweetsets_data/full_datasets
       # Using host networking so that spark can choose own ports
       # and the ports inside the container match the ports outside
       # the container. (Spark needs to be able to share the correct
@@ -23,3 +24,4 @@ services:
         - ES_HOST=${HOSTNAME}
         - SPARK_DRIVER_HOST=${HOSTNAME}
         - SPARK_MASTER_HOST=${HOSTNAME}
+        - PATH_TO_EXTRACTS=/tweetsets_data/full_datasets

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   loader:
-      image: gwul/tweetsets-loader
-      #build:
-      #    context: ..
-      #    dockerfile: Dockerfile-loader
+      #image: gwul/tweetsets-loader
+      build:
+          context: ..
+          dockerfile: Dockerfile-loader
       logging:
           driver: json-file
           options:
@@ -13,11 +13,15 @@ services:
       volumes:
         - ${DATASET_PATH}:/dataset
         - ${TWEETSETS_DATA_PATH}/full_datasets:/tweetsets_data/full_datasets
+        - "../tweetset_loader.py:/opt/tweetsets/tweetset_loader.py"
+        - "../spark_utils.py:/opt/tweetsets/spark_utils.py"
       # Using host networking so that spark can choose own ports
       # and the ports inside the container match the ports outside
       # the container. (Spark needs to be able to share the correct
       # ports.)
       network_mode: "host"
+      ports:
+        - 4040:4040
       environment:
         - TZ
         - STORE_TWEET
@@ -25,3 +29,5 @@ services:
         - SPARK_DRIVER_HOST=${HOSTNAME}
         - SPARK_MASTER_HOST=${HOSTNAME}
         - PATH_TO_EXTRACTS=/tweetsets_data/full_datasets
+        - SPARK_MAX_FILE_SIZE
+        - SPARK_PARTITION_SIZE

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   loader:
-      #image: gwul/tweetsets-loader
-      build:
-          context: ..
-          dockerfile: Dockerfile-loader
+      image: gwul/tweetsets-loader
+      #build:
+      #    context: ..
+      #    dockerfile: Dockerfile-loader
       logging:
           driver: json-file
           options:

--- a/docker/loader.docker-compose.yml
+++ b/docker/loader.docker-compose.yml
@@ -13,13 +13,15 @@ services:
       volumes:
         - ${DATASET_PATH}:/dataset
         - ${TWEETSETS_DATA_PATH}/full_datasets:/tweetsets_data/full_datasets
-        - "../tweetset_loader.py:/opt/tweetsets/tweetset_loader.py"
-        - "../spark_utils.py:/opt/tweetsets/spark_utils.py"
+        # Uncomment the following lines for development
+        #- "../tweetset_loader.py:/opt/tweetsets/tweetset_loader.py"
+        #- "../spark_utils.py:/opt/tweetsets/spark_utils.py"
       # Using host networking so that spark can choose own ports
       # and the ports inside the container match the ports outside
       # the container. (Spark needs to be able to share the correct
       # ports.)
       network_mode: "host"
+      # Exposes Spark Jobs UI
       ports:
         - 4040:4040
       environment:

--- a/spark_utils.py
+++ b/spark_utils.py
@@ -50,7 +50,7 @@ def compute_read_partitions(input_files):
     partition_size = os.environ.get('SPARK_PARTITION_SIZE', '128m')
     partition_size = parse_size(partition_size, 'SPARK_PARTITION_SIZE')
     # Number of partitions
-    return int(total_size/partition_size)
+    return int(total_size/partition_size) or 1
     
 def apply_partitions(spark_obj, num_partitions, files):
     '''Applies either a repartition or a coalesce, depending on whether the number of partitions is greater or less than the number of input files. Coalescing generally performs better than repartitioning when *reducing* the number of partitions.

--- a/spark_utils.py
+++ b/spark_utils.py
@@ -4,6 +4,64 @@ import pyspark.sql.functions as F
 from pyspark.sql import Row
 import json
 from twarc import json2csv
+import os
+import re
+import logging
+
+log = logging.getLogger(__name__)
+
+def parse_size(size, env):
+    '''Parses a string containing a size that may be in kilobytes, megabytes, or gigabytes.
+    :param size: string representation of size
+    :param env: string corresponding to an environment variable name (used for error messaging)'''
+    try:
+        num, factor = re.match('(\d+)([kmg])', size).groups()
+    except AttributeError:
+        log.exception(f'Environment variable {env} incorrectly specified. Should be one or more digits followed by either m (megabytes), k (kilobytes) or g (gigabytes).')
+        raise
+    # Convert GB, MB, or KB to bytes
+    return int(num) * {'g': 1000**3, 'm': 10**6, 'k': 1000}.get(factor)
+
+def compute_output_partitions(tweet_count): 
+    '''Calculates how many partitions necessary to achieve the target file size for spark.write, as defined in the environment variable MAX_SPARK_FILE_SIZE. Returns a dictionary mapping extract type to target partitions.
+    :param tweet_count: total number of tweets in the collection
+    '''
+    # Derived from sample of 300K tweets / size in bytes per tweet per extract
+    sizes = {'json': 3907.8411268075424,
+            'csv': 184.07439405127573,
+            'mentions-edges': 14.501095724125433,
+            'mentions-nodes': 7.717282851721618,
+            'mentions-agg': 5.743666510612312,
+            'ids': 8.977668650717135,
+            'users': 40.01428571428571}
+    # Get target file size
+    max_size_env = os.environ.get('SPARK_MAX_FILE_SIZE', '2g') # Applying default of 2 GB
+    max_size = parse_size(max_size_env, 'SPARK_MAX_FILE_SIZE')
+    # The number of files should be the total number of tweets divided by the number of tweets per file of this extract type, given the file size target
+    return {k: int((tweet_count * v)/ max_size ) or 1 
+            for k,v in sizes.items()}
+
+def compute_read_partitions(input_files):
+    '''Computes number of partitions to apply after reading data with spark.read/SparkContext.textFile, in order to achieve target partition size.
+    :param input_files: list of files (for computing total file size) 
+    '''
+    # Compute size in bytes
+    total_size = sum([os.stat(f).st_size for f in input_files])
+    partition_size = os.environ.get('SPARK_PARTITION_SIZE', '128m')
+    partition_size = parse_size(partition_size, 'SPARK_PARTITION_SIZE')
+    # Number of partitions
+    return int(total_size/partition_size)
+    
+def apply_partitions(spark_obj, num_partitions, files):
+    '''Applies either a repartition or a coalesce, depending on whether the number of partitions is greater or less than the number of input files. Coalescing generally performs better than repartitioning when *reducing* the number of partitions.
+    :param spark_obj: a Spark DataFrame or RDD
+    :param num_partitions: a target number of partitions
+    :param files: a list of input files
+    '''
+    if num_partitions > len(files):
+        return spark_obj.repartition(num_partitions)
+    else:
+        return spark_obj.coalesce(num_partitions)
 
 def load_schema(path_to_schema):
     '''Load TweetSets Spark DataFrame schema
@@ -18,7 +76,7 @@ def load_sql(path_to_sql):
     with open(path_to_sql, 'r') as f:
         return f.read()
 
-def make_spark_df(spark, schema, sql, path_to_dataset, dataset_id):
+def make_spark_df(spark, schema, sql, path_to_dataset, dataset_id, num_partitions=None):
     '''Loads a set of JSON tweets and applies the SQL transform.
     
     :param spark: an initialized SparkSession object
@@ -27,8 +85,10 @@ def make_spark_df(spark, schema, sql, path_to_dataset, dataset_id):
     :param path_to_dataset: a comma-separated list of JSON files to load
     :param dataset_id: a string containing the ID for this dataset'''
     # Read JSON files as Spark DataFrame
-    #df = load_rdd(spark, tweet_schema=schema, path_to_tweets=path_to_dataset)
     df = spark.read.schema(schema).json(path_to_dataset)
+    # Apply repartition/coalesce
+    if num_partitions:
+        df = apply_partitions(df, num_partitions=num_partitions, files=path_to_dataset)
     # Create a temp view for the SQL ops
     df.createOrReplaceTempView("tweets")
     # Apply SQL transform
@@ -40,12 +100,21 @@ def make_spark_df(spark, schema, sql, path_to_dataset, dataset_id):
     df = df.withColumn('dataset_id', F.lit(dataset_id))
     return df
 
-def extract_tweet_ids(df, path_to_extract):
+
+def save_to_csv(df, path_to_extract, num_partitions=None):
+    '''Performs DataFrame.write.csv with supplied parameters.
+    :param df: a Spark DataFrame
+    :param path_to_extract: a file path for the CSV (should be folder-level)
+    :param num_partitions: if supplied, number of files to create.'''
+    if num_partitions:
+        df = df.coalesce(num_partitions)
+    df.write.option('header', 'true').csv(path_to_extract, compression='gzip', escape='"')
+
+def extract_tweet_ids(df):
     '''Saves Tweet ID's from a dataset to the provided path as zipped CSV files.
-    :param df: Spark DataFrame
-    :parm path_to_extract: string of path to folder for files'''
+    :param df: Spark DataFrame'''
     # Extract ID column and save as zipped CSV
-    df.select('tweet_id').distinct().coalesce(14).write.option("header", "true").csv(path_to_extract, compression='gzip')
+    return df.select('tweet_id').distinct()
     
 def extract_tweet_json(df, path_to_extract):
     '''Saves Tweet JSON documents from a dataset to the provided path as zipped JSON files.
@@ -126,7 +195,7 @@ def extract_mentions(df, spark):
     mention_nodes = mentions_df.select('mention_user_ids', 'user_id').distinct()
     return mention_nodes, mention_edges
 
-def agg_mentions(df, spark):
+def extract_agg_mentions(df, spark):
     '''Creates count of Tweets per mentioned user id.
     :param df: Spark DataFrame (after SQL transform)
     :param spark: SparkSession object'''
@@ -146,7 +215,7 @@ def agg_mentions(df, spark):
     mentions_agg_df = spark.sql(sql_agg)  
     return mentions_agg_df
 
-def agg_users(df, spark):
+def extract_agg_users(df, spark):
     '''Creates count of tweets per user id/screen name.
     :param df: Spark DataFrame (after SQL transform)
     :param spark: SparkSession object'''

--- a/spark_utils.py
+++ b/spark_utils.py
@@ -45,7 +45,7 @@ def extract_tweet_ids(df, path_to_extract):
     :param df: Spark DataFrame
     :parm path_to_extract: string of path to folder for files'''
     # Extract ID column and save as zipped CSV
-    df.select('tweet_id').distinct().write.option("header", "true").csv(path_to_extract, compression='gzip')
+    df.select('tweet_id').distinct().coalesce(14).write.option("header", "true").csv(path_to_extract, compression='gzip')
     
 def extract_tweet_json(df, path_to_extract):
     '''Saves Tweet JSON documents from a dataset to the provided path as zipped JSON files.

--- a/tweetset_loader.py
+++ b/tweetset_loader.py
@@ -370,6 +370,9 @@ if __name__ == '__main__':
                                 sql=ts_sql, 
                                 path_to_dataset=filepath_list,
                                 dataset_id=dataset_id)
+            # Reduce number of partitions to constrain number of gzipped files creates
+            num_partitions = (tweet_count / 25000) or 1
+            df = df.coalesce(num_partitions)
             # Create and save tweet ID's
             tweet_ids_path = os.path.join(full_dataset_path, 'tweet-ids')
             log.info(f'Saving tweet IDs to {tweet_ids_path}.')

--- a/tweetset_loader.py
+++ b/tweetset_loader.py
@@ -375,7 +375,7 @@ if __name__ == '__main__':
             # read dataset as RDD (for loading into Elasticsearch)
             tweets_str_rdd = spark.sparkContext.textFile(','.join(filepath_list))
             # repartition or coalesce for improved performance
-            apply_partitions(tweets_str_rdd, num_partitions, filepath_list)
+            tweets_str_rdd = apply_partitions(tweets_str_rdd, num_partitions, filepath_list)
             # Apply transform
             tweets_rdd = tweets_str_rdd.map(to_tweet_dict).map(lambda row: (row['tweet_id'], row))
             log.info('Saving tweets to Elasticsearch.')

--- a/tweetset_loader.py
+++ b/tweetset_loader.py
@@ -371,7 +371,7 @@ if __name__ == '__main__':
                                 path_to_dataset=filepath_list,
                                 dataset_id=dataset_id)
             # Reduce number of partitions to constrain number of gzipped files creates
-            num_partitions = (tweet_count / 25000) or 1
+            num_partitions = int(tweet_count / 25000) or 1
             df = df.coalesce(num_partitions)
             # Create and save tweet ID's
             tweet_ids_path = os.path.join(full_dataset_path, 'tweet-ids')

--- a/tweetset_loader.py
+++ b/tweetset_loader.py
@@ -388,7 +388,7 @@ if __name__ == '__main__':
             agg_mentions(df, spark).write.option("header", "true").csv(os.path.join(mentions_path, 'agg-mentions'), compression='gzip')
             # Create and save user counts
             users_path = os.path.join(full_dataset_path, 'tweet-users')
-            agg_users(df, spark).option('header', 'true').csv(users_path, compression='gzip', escape='"')
+            agg_users(df, spark).write.option('header', 'true').csv(users_path, compression='gzip', escape='"')
         finally:
             spark.stop()
         # Copy full JSON tweet files to extracts directory

--- a/tweetset_loader.py
+++ b/tweetset_loader.py
@@ -52,7 +52,7 @@ def copy_json(json_files, dataset_id):
         return
     json_extract_dir = os.path.join(full_dataset_path, dataset_id, 'tweet-json')
     if not os.path.isdir(json_extract_dir):
-        os.mkdirs(json_extract_dir)
+        os.makedirs(json_extract_dir)
     log.info(f'Copying {len(json_files)} JSON files to {json_extract_dir}.')
     for file in json_files:
         copy(file, json_extract_dir)

--- a/tweetset_loader.py
+++ b/tweetset_loader.py
@@ -389,9 +389,9 @@ if __name__ == '__main__':
                                 dataset_id=dataset_id)
             # Reduce number of partitions to constrain number of gzipped files creates
             log.info(f'Number partitions before coalesce = {df.rdd.getNumPartitions()}')
-            num_partitions = int(tweet_count / 25000) or 1
-            df = df.coalesce(num_partitions)
-            log.info(f'Number partitions after coalesce = {df.rdd.getNumPartitions()}')
+            #num_partitions = int(tweet_count / 25000) or 1
+            #df = df.coalesce(num_partitions)
+            #log.info(f'Number partitions after coalesce = {df.rdd.getNumPartitions()}')
             # Create and save tweet ID's
             tweet_ids_path = os.path.join(full_dataset_path, 'tweet-ids')
             log.info(f'Saving tweet IDs to {tweet_ids_path}.')

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -230,9 +230,9 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
                 'nodes/edges': ('mention-*.csv.zip',
                         'tweet-mentions/edges/*.csv.gz',
                         'tweet-mentions/nodes/*.csv.gz'),
-                'agg_mentions': ('top-mentions-*.csv.zip',
+                'mentions_agg': ('top-mentions-*.csv.zip',
                                 'tweet-mentions/agg-mentions/*.csz/gz'),
-                'agg_users': ('top-users-*.csv.zip',
+                'users_agg': ('top-users-*.csv.zip',
                             'tweet-users/*.csv.gz')}
     p = Path(dataset_path)
     filenames = []

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -298,9 +298,13 @@ def limit_dataset():
         return render_template('dataset.html', **context)
 
 @app.route('/full-dataset-file/<dataset_id>/<filename>', defaults={'full_dataset': True}, endpoint='full_dataset_file')
+@app.route('/full-dataset-file/<dataset_id>/<path:extract_subpath>/<filename>', defaults={'full_dataset': True}, endpoint='full_dataset_file')
 @app.route('/dataset-file/<dataset_id>/<filename>')
-def dataset_file(dataset_id, filename, full_dataset=False):
-    filepath = os.path.join(_dataset_path(dataset_id, full_dataset), filename)
+def dataset_file(dataset_id, filename, extract_subpath=None, full_dataset=False):
+    if extract_subpath:
+        filepath = os.path.join(_dataset_path(dataset_id, full_dataset), extract_subpath, filename)
+    else:
+        filepath = os.path.join(_dataset_path(dataset_id, full_dataset), filename)
     return send_file(filepath, as_attachment=True, attachment_filename=filename)
 
 

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -231,7 +231,7 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
                         'tweet-mentions/edges/*.csv.gz',
                         'tweet-mentions/nodes/*.csv.gz'),
                 'mentions_agg': ('top-mentions-*.csv.zip',
-                                'tweet-mentions/agg-mentions/*.csz.gz'),
+                                'tweet-mentions/agg-mentions/*.csv.gz'),
                 'users_agg': ('top-users-*.csv.zip',
                             'tweet-users/*.csv.gz')}
     p = Path(dataset_path)

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -240,8 +240,10 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
     filenames = []
     # Iterate over possible patterns
     for pattern in patterns[filter]:
-        # Extract just the file name
-        filenames.extend([f.name for f in  p.glob(pattern)])
+        # to account for nested directories
+        pattern_path = Path(pattern)
+        # Extract just the file name and add its relative parent
+        filenames.extend([pattern_path.parent / f.name for f in  p.glob(pattern)])
     if filenames and not hide:
         filenames.sort()
         filename_list.append((label, filenames))

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -231,7 +231,7 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
                         'tweet-mentions/edges/*.csv.gz',
                         'tweet-mentions/nodes/*.csv.gz'),
                 'mentions_agg': ('top-mentions-*.csv.zip',
-                                'tweet-mentions/agg-mentions/*.csz/gz'),
+                                'tweet-mentions/agg-mentions/*.csz.gz'),
                 'users_agg': ('top-users-*.csv.zip',
                             'tweet-users/*.csv.gz')}
     p = Path(dataset_path)

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -222,7 +222,9 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
     '''
     patterns = {'json': ('tweets-*.jsonl.zip',
                         'tweet-json/*.json.gz',
-                        'tweet-json/*.jsonl.gz'),
+                        'tweet-json/*.jsonl.gz'
+                        'tweet-json/*.jsonl',
+                        'tweet-json/*.json'),
                 'ids': ('tweet-ids-*.txt.zip',
                         'tweet-ids/*.csv.gz'),
                 'csv': ('tweets-*.csv.zip',
@@ -238,7 +240,8 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
     filenames = []
     # Iterate over possible patterns
     for pattern in patterns[filter]:
-        filenames.extend(list(p.glob(pattern)))
+        # Extract just the file name
+        filenames.extend([f.name for f in  p.glob(pattern)])
     if filenames and not hide:
         filenames.sort()
         filename_list.append((label, filenames))

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -197,12 +197,12 @@ def dataset(dataset_id, full_dataset=False):
 
     # Check for existing exports
     filenames_list = []
-    _add_filenames('Generated tweet JSON files', 'json', dataset_path, filenames_list, hide=not context['is_local_mode'])
-    _add_filenames('Generated tweet CSV files', 'csv', dataset_path, filenames_list, hide=not context['is_local_mode'])
-    _add_filenames('Generated tweet id files', 'ids', dataset_path, filenames_list)
-    _add_filenames('Generated mentions nodes/edges files', 'nodes/edges', dataset_path, filenames_list)
-    _add_filenames('Generated aggregate mentions files', 'mentions_agg', dataset_path, filenames_list)
-    _add_filenames('Generated aggregate users files', 'users_agg', dataset_path, filenames_list)
+    _add_filenames('Tweet JSON files', 'json', dataset_path, filenames_list, hide=not context['is_local_mode'])
+    _add_filenames('Tweet CSV files', 'csv', dataset_path, filenames_list, hide=not context['is_local_mode'])
+    _add_filenames('Tweet id files', 'ids', dataset_path, filenames_list)
+    _add_filenames('Mentions nodes/edges files', 'nodes/edges', dataset_path, filenames_list)
+    _add_filenames('Mention counts by user', 'mentions_agg', dataset_path, filenames_list)
+    _add_filenames('Tweet counts by user', 'users_agg', dataset_path, filenames_list)
     context['filenames_list'] = filenames_list
 
     context['dataset_id'] = dataset_id

--- a/tweetset_server.py
+++ b/tweetset_server.py
@@ -222,7 +222,7 @@ def _add_filenames(label, filter, dataset_path, filename_list, hide=False):
     '''
     patterns = {'json': ('tweets-*.jsonl.zip',
                         'tweet-json/*.json.gz',
-                        'tweet-json/*.jsonl.gz'
+                        'tweet-json/*.jsonl.gz',
                         'tweet-json/*.jsonl',
                         'tweet-json/*.json'),
                 'ids': ('tweet-ids-*.txt.zip',


### PR DESCRIPTION
### Features
- Updates UI to display full extracts created by Spark
- Reuses existing `full_datasets` path (assuming this is or can be configured as an NFS mount)
- Adds aggregate users extract type
- Copies JSON files from `dataset_loading` to `tweetsets-data/full_datasets` (or equivalent paths as defined in `.env`)
- Uses repartitioning to optimize loading of multiple files
- Coalesces extracts into a smaller number of files, using the max file size `.env` variable

### Setup
1. The `full_datasets` folder must be a shared NFS mount available to all nodes in the Spark cluster. (On my VM, I moved the `tweetsets_data` folder to `/storage` on both the primary and secondary nodes, then mapped the `full_datasets` folder on the primary to the same location on the secondary VM.) 
    - Note: you don't want to share the entire `tweetsets_data` folder, as that will likely cause problems for Elasticsearch.
    - I initially tried mapping `/storage/tweetsets_data/full_datasets` (VM 1) to a folder on VM 2 in `/home/dsmith`, but that did not seem to work.
2. Update your `.env` files accordingly with the new paths, if necessary.
3. On your non-primary nodes, update `docker-compose.yml` as follows:
    - Add the following line to the `spark-worker` section, under `volumes`: `${TWEETSETS_DATA_PATH}/full_datasets:/tweetsets_data/full_datasets`
4. On the primary node, update `loader.docker-compose.yml` as follows:
     - Under `volumes`, add ` ${TWEETSETS_DATA_PATH}/full_datasets:/tweetsets_data/full_datasets`
     - Under `environment`, add 
          - `SPARK_MAX_FILE_SIZE`
          - `SPARK_PARTITION_SIZE`
     - Optional:add the following (in order to expose the Spark jobs UI): 
     ```
     ports:
        - 4040:4040
      ```
5. To your primary node's `.env`, add the following:
     - `SPARK_MAX_FILE_SIZE=2g`
     - `SPARK_PARTITION_SIZE=128m`
6. For testing, the `server-flaskrun` and `loader` containers should be built locally. Make sure you rebuild the images before restarting the containers.

### Testing
1. Load a dataset.
2. Verify that full extracts are created and available in the UI.
3. Verify that extracts are downloadable and that, for all extracts except the full-tweet JSON, a small number of files are created. (For smaller datasets, each extract should have one file.)
4. Verify that the number of (non-header) rows in the `tweet-ids` extract matches the number of tweets in the UI.
5. Create custom extracts and verify that these are downloadable and created correctly. 

### Benchmarks

The following metrics were obtained using a subset of the Summer Olympics collection. 

| Metric | Value |
| ------ | ------ |
| Number of workers | 1 |
| Number of cores | 2 |
| Number of tweets | 1,048,637 |
| Size on disk | 980M |
| Number of gzipped files | 32 |

| Operation | Time | 
| ---------- | ----- |
| RDD -> Elasticsearch | 12 min |
| tweet-ids | 50 sec |
| tweet-csv | 3.8 min |
| tweet-mentions/nodes | 1.1 min |
| tweet-mentions/edges | 55 s |
| tweet-mentions/agg | 1 min |
| tweet-users | 1 min |