### PR TITLE
Updated models & tests

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,8 +61,7 @@ class TestTweet(TestCase):
     def test_quote(self):
         tweet = to_tweet(quote_tweet, 'test', 'test_index')
         self.assertEqual('quote', tweet.tweet_type)
-        self.assertEqual(('Test 10. Retweet. https://t.co/tBu6RRJoKr',
-                          'First day at Gelman Library. First tweet. http://t.co/Gz5ybAD6os',), tweet.text)
+        self.assertEqual(('Test 10. Retweet. https://t.co/tBu6RRJoKr',), tweet.text)
         self.assertTrue(tweet.urls)
         self.assertEqual('justin_littman', tweet.retweeted_quoted_screen_name)
         self.assertEqual('481186914', tweet.retweeted_quoted_user_id)


### PR DESCRIPTION
`to_tweet` function has been updated (and its dependent functions) to align it with twarc `json2csv` 1.12.1. This affects the following:
- text in `quoted_status` is NOT added to the `text` field.
- hashtags from `retweeted_status.extended_tweet.entities` and `retweeted_status.entities` are included.
- urls are included from both `extended_tweet.entities` as well as `entities` (as these can be different).
- `favorite_count` is included from `retweeted_status` (when present).

### Testing
Load a collection with this branch to compare with the same collection loaded with the `master` branch.
- Compare results for all types for keyword and hashtag searches.
- Counts will differ, especially for `quote` type, though the changes above will affect the other counts to some degree, too.